### PR TITLE
Fix parsing ini file in get_transcript.php

### DIFF
--- a/etc/bigbluebutton.custom/bbb-transcript/test_scripts/test_get_transcript.php
+++ b/etc/bigbluebutton.custom/bbb-transcript/test_scripts/test_get_transcript.php
@@ -56,7 +56,7 @@ $checksum = "fake_checksum";
 
 if (!isset($options['correct_checksum']) || $options['correct_checksum'] !== 'false') {
 	// Generate the correct checksum
-	$secret_config = parse_ini_file($config['secret-path']);
+	$secret_config = parse_ini_file($config['secret-path'], INI_SCANNER_RAW);
 	if ($secret_config === false) {
 	        echo "Failed to parse the secret file.";
 	        exit();

--- a/var/www/bbb-transcript/get_transcript.php
+++ b/var/www/bbb-transcript/get_transcript.php
@@ -62,7 +62,7 @@ if (!$checksum) {
 }
 
 // Check secret code with secret bbb-conf (sha256)
-$secret_config = parse_ini_file($config['secret-path']);
+$secret_config = parse_ini_file($config['secret-path'], INI_SCANNER_RAW);
 if ($secret_config === false) {
         $error = json_encode(['error' => 'Unable to verify checksum (failed to parse secret file).']);
 	throw_error($logger, 500, 'Unable to verify checksum (failed to parse secret file).', $error);


### PR DESCRIPTION
Hi,

Parsing ini files with `parse_ini_file` function sometimes fail especially in case there are missing double quotes around parameters.

This occurs for instance in the file bbb-web.properties

Adding as second parameter `INI_SCANNER_RAW`to the function fixes the case. See section "scanner mode" in https://www.php.net/manual/en/function.parse-ini-file.php

This PR simply adds the parameter at both places where `parse_ini_file` is used.

Kind regards,
Thierry